### PR TITLE
The CredentialsOptional flag was being ignored

### DIFF
--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -88,6 +88,9 @@ func (m *JWTMiddleware) CheckJWT(w http.ResponseWriter, r *http.Request) error {
 
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
+		if m.Options.CredentialsOptional {
+			return nil
+		}
 		errorMsg := "Authorization header isn't sent"
 		m.Options.ErrorHandler(w, r, errorMsg)
 		return errors.New(errorMsg)


### PR DESCRIPTION
Presumably, the purpose of the CredentialsOptional flag was to allow
requests to pass through this middleware without an Authorization
header (or to prevent requests without an Authorization header from
getting through, depending on the setting).

Unfortunately, while the flag is present, it is ignored.  This corrects
the situation by using it to determine whether it is an error for a
request to be missing the authorization header.