### PR TITLE
Allow extracting tokens in different ways

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ type Options struct {
   // Default value: false
   CredentialsOptional bool
   // A function that extracts the token from the request
+  // Default: FromAuthHeader (i.e., from Authorization header as bearer token)
   Extractor TokenExtractor
   // Debug flag turns on debugging output
+  // Default: false  
   Debug bool
 }
 ````

--- a/README.md
+++ b/README.md
@@ -104,8 +104,45 @@ type Options struct {
   // A boolean indicating if the credentials are required or not
   // Default value: false
   CredentialsOptional bool
+  // A function that extracts the token from the request
+  Extractor TokenExtractor
+  // Debug flag turns on debugging output
+  Debug bool
 }
 ````
+
+### Token Extraction
+
+The default value for the `Extractor` option is the `FromAuthHeader`
+function which assumes that the JWT will be provided as a bearer token
+in an `Authorization` header, i.e.,
+
+```
+Authorization: bearer {token}
+```
+
+To extract the token from a query string parameter, you can use the
+`FromParameter` function, e.g.,
+
+```go
+jwtmiddleware.New(jwtmiddleware.Options{
+  Extractor: jwtmiddleware.FromParameter("auth_code"),
+})
+```
+
+In this case, the `FromParameter` function will look for a JWT in the
+`auth_code` query parameter.
+
+Or, if you want to allow both, you can use the `FromFirst` function to
+try and extract the token first in one way and then in one or more
+other ways, e.g.,
+
+```go
+jwtmiddleware.New(jwtmiddleware.Options{
+	Extractor: jwtmiddleware.FromFirst(jwtmiddleware.FromAuthHeader,
+	                                   jwtmiddleware.FromParameter("auth_code")),
+})
+```
 
 ## Examples
 

--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -36,8 +36,10 @@ type Options struct {
 	// Default value: false
 	CredentialsOptional bool
 	// A function that extracts the token from the request
+	// Default: FromAuthHeader (i.e., from Authorization header as bearer token)
 	Extractor TokenExtractor
 	// Debug flag turns on debugging output
+	// Default: false
 	Debug bool
 }
 

--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -156,12 +156,10 @@ func (m *JWTMiddleware) CheckJWT(w http.ResponseWriter, r *http.Request) error {
 	token, err := m.Options.Extractor(r)
 
 	// If debugging is turned on, log the outcome
-	if m.Options.Debug {
-		if err != nil {
-			log.Printf("Error extracting JWT: %v", err)
-		} else {
-			log.Printf("Token extracted: %s", token)
-		}
+	if err != nil {
+		m.logf("Error extracting JWT: %v", err)
+	} else {
+		m.logf("Token extracted: %s", token)
 	}
 
 	// If an error occurs, call the error handler and return an error

--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -1,14 +1,23 @@
 package jwtmiddleware
 
 import (
-	"errors"
+	"fmt"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/context"
+	"log"
 	"net/http"
 	"strings"
 )
 
+// A function called whenever an error is encountered
 type errorHandler func(w http.ResponseWriter, r *http.Request, err string)
+
+// TokenExtractor is a function that takes a request as input and returns
+// either a token or an error.  An error should only be returned if an attempt
+// to specify a token was found, but the information was somehow incorrectly
+// formed.  In the case where a token is simply not present, this should not
+// be treated as an error.  An empty string should be returned in that case.
+type TokenExtractor func(r *http.Request) (string, error)
 
 // Options is a struct for specifying configuration options for the middleware.
 type Options struct {
@@ -26,6 +35,10 @@ type Options struct {
 	// A boolean indicating if the credentials are required or not
 	// Default value: false
 	CredentialsOptional bool
+	// A function that extracts the token from the request
+	Extractor TokenExtractor
+	// Debug flag turns on debugging output
+	Debug bool
 }
 
 type JWTMiddleware struct {
@@ -52,6 +65,10 @@ func New(options ...Options) *JWTMiddleware {
 
 	if opts.ErrorHandler == nil {
 		opts.ErrorHandler = OnError
+	}
+
+	if opts.Extractor == nil {
+		opts.Extractor = FromAuthHeader
 	}
 
 	return &JWTMiddleware{
@@ -84,38 +101,116 @@ func (m *JWTMiddleware) Handler(h http.Handler) http.Handler {
 	})
 }
 
-func (m *JWTMiddleware) CheckJWT(w http.ResponseWriter, r *http.Request) error {
-
+// FromAuthHeader is a "TokenExtractor" that takes a give request and extracts
+// the JWT token from the Authorization header.
+func FromAuthHeader(r *http.Request) (string, error) {
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
-		if m.Options.CredentialsOptional {
-			return nil
-		}
-		errorMsg := "Authorization header isn't sent"
-		m.Options.ErrorHandler(w, r, errorMsg)
-		return errors.New(errorMsg)
+		return "", nil // No error, just no token
 	}
 
+	// TODO: Make this a bit more robust, parsing-wise
 	authHeaderParts := strings.Split(authHeader, " ")
 	if len(authHeaderParts) != 2 || strings.ToLower(authHeaderParts[0]) != "bearer" {
-		errorMsg := "Authorization header format must be Bearer {token}"
-		m.Options.ErrorHandler(w, r, errorMsg)
-		return errors.New(errorMsg)
+		return "", fmt.Errorf("Authorization header format must be Bearer {token}")
 	}
 
-	token := authHeaderParts[1]
+	return authHeaderParts[1], nil
+}
 
-	parsedToken, err := jwt.Parse(token, m.Options.ValidationKeyGetter)
+// FromParameter returns a function that extracts the token from the specified
+// query string parameter
+func FromParameter(param string) TokenExtractor {
+	return func(r *http.Request) (string, error) {
+		return r.URL.Query().Get(param), nil
+	}
+}
 
+// FromFirst returns a function that runs multiple token extractors and takes the
+// first token it finds
+func FromFirst(extractors ...TokenExtractor) TokenExtractor {
+	return func(r *http.Request) (string, error) {
+		for _, ex := range extractors {
+			token, err := ex(r)
+			if err != nil {
+				return "", err
+			}
+			if token != "" {
+				return token, nil
+			}
+		}
+		return "", nil
+	}
+}
+
+func (m *JWTMiddleware) CheckJWT(w http.ResponseWriter, r *http.Request) error {
+	// Use the specified token extractor to extract a token from the request
+	token, err := m.Options.Extractor(r)
+
+	// If debugging is turned on, log the outcome
+	if m.Options.Debug {
+		if err != nil {
+			log.Printf("Error extracting JWT: %v", err)
+		} else {
+			log.Printf("Token extracted: %s", token)
+		}
+	}
+
+	// If an error occurs, call the error handler and return an error
 	if err != nil {
 		m.Options.ErrorHandler(w, r, err.Error())
-		return err
+		return fmt.Errorf("Error extracting token: %v", err)
 	}
 
+	// If the token is empty...
+	if token == "" {
+		// Check if it was required
+		if m.Options.CredentialsOptional {
+			if m.Options.Debug {
+				log.Printf("  No credentials found (CredentialsOptional=true)")
+			}
+			// No error, just no token (and that is ok given that CredentialsOptional is true)
+			return nil
+		}
+
+		// If we get here, the required token is missing
+		errorMsg := "Required authorization token not found"
+		m.Options.ErrorHandler(w, r, errorMsg)
+		if m.Options.Debug {
+			log.Printf("  Error: No credentials found (CredentialsOptional=false)")
+		}
+		return fmt.Errorf(errorMsg)
+	}
+
+	// Now parse the token
+	parsedToken, err := jwt.Parse(token, m.Options.ValidationKeyGetter)
+
+	// Check if there was an error in parsing...
+	if err != nil {
+		if m.Options.Debug {
+			log.Printf("Error parsing token: %v", err)
+		}
+
+		m.Options.ErrorHandler(w, r, err.Error())
+		return fmt.Errorf("Error parsing token: %v", err)
+	}
+
+	// Check if the parsed token is valid...
 	if !parsedToken.Valid {
+		if m.Options.Debug {
+			log.Printf("Token is invalid")
+		}
+
 		m.Options.ErrorHandler(w, r, "The token isn't valid")
+		return fmt.Errorf("Token is invalid")
 	}
 
+	if m.Options.Debug {
+		log.Printf("JWT: %v", parsedToken)
+	}
+
+	// If we get here, everything worked and we can set the
+	// user property in context.
 	context.Set(r, m.Options.UserProperty, parsedToken)
 
 	return nil


### PR DESCRIPTION
This pull request is in response to the discussion in #2.  This allows the user to specify how the token is extracted from the request.  This change is backward compatible with previous versions because the default choice for how tokens are extracted is the same as it was before this became configurable (i.e., to extract it from the `Authorization` header using the `Bearer` scheme.