### PR TITLE
Adding ability to disable auth for preflight requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ type Options struct {
   // Debug flag turns on debugging output
   // Default: false  
   Debug bool
+  // When set, all requests with the OPTIONS method will use authentication
+  // Default: false
+  EnableAuthOnOptions bool
 }
 ````
 

--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -41,6 +41,9 @@ type Options struct {
 	// Debug flag turns on debugging output
 	// Default: false
 	Debug bool
+	// When set, all requests with the OPTIONS method will bypass auth
+	// Default: false
+	DisableAuthOnOptions bool
 }
 
 type JWTMiddleware struct {
@@ -152,6 +155,12 @@ func FromFirst(extractors ...TokenExtractor) TokenExtractor {
 }
 
 func (m *JWTMiddleware) CheckJWT(w http.ResponseWriter, r *http.Request) error {
+	if m.Options.DisableAuthOnOptions{
+		if r.Method == "OPTIONS"{
+			return nil
+		}
+	}
+	
 	// Use the specified token extractor to extract a token from the request
 	token, err := m.Options.Extractor(r)
 

--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -41,9 +41,9 @@ type Options struct {
 	// Debug flag turns on debugging output
 	// Default: false
 	Debug bool
-	// When set, all requests with the OPTIONS method will bypass auth
+	// When set, all requests with the OPTIONS method will use authentication
 	// Default: false
-	DisableAuthOnOptions bool
+	EnableAuthOnOptions bool
 }
 
 type JWTMiddleware struct {
@@ -155,7 +155,7 @@ func FromFirst(extractors ...TokenExtractor) TokenExtractor {
 }
 
 func (m *JWTMiddleware) CheckJWT(w http.ResponseWriter, r *http.Request) error {
-	if m.Options.DisableAuthOnOptions{
+	if !m.Options.EnableAuthOnOptions{
 		if r.Method == "OPTIONS"{
 			return nil
 		}


### PR DESCRIPTION
Regarding CORS:  The authorization header is not a
[simple header](http://www.w3.org/TR/cors/#simple-header). Because of this,
the browser strips off the authorization header when making a preflight.

The user should have the option, when using jwt-middleware for authorization,
to disable authorization on OPTIONS methods.

This commit allows the user to set `DisableAuthOnOptions` in the config.
When set (defaults to not set) requests on the OPTIONS method bypass the
CheckJWT method.