### PR TITLE
updated FromAuthHeader to use strings.Fields instead of spliting stri…

### DIFF
--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -121,7 +121,7 @@ func FromAuthHeader(r *http.Request) (string, error) {
 	}
 
 	// TODO: Make this a bit more robust, parsing-wise
-	authHeaderParts := strings.Split(authHeader, " ")
+	authHeaderParts := strings.Fields(authHeader)
 	if len(authHeaderParts) != 2 || strings.ToLower(authHeaderParts[0]) != "bearer" {
 		return "", fmt.Errorf("Authorization header format must be Bearer {token}")
 	}


### PR DESCRIPTION
updated FromAuthHeader to use strings.Fields instead of spliting strings by space to make parsing logic more robust.
