### PR TITLE
Fix import cycle issue in test

### DIFF
--- a/jwtmiddleware_test.go
+++ b/jwtmiddleware_test.go
@@ -1,4 +1,4 @@
-package jwtmiddleware
+package jwtmiddleware_test
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Currently `go test .` fails.

```
$ go test .
# github.com/auth0/go-jwt-middleware
import cycle not allowed in test
package github.com/auth0/go-jwt-middleware (test)
    imports github.com/auth0/go-jwt-middleware

FAIL    github.com/auth0/go-jwt-middleware [setup failed]
```

Changing test file's namespace to `jwtmiddleware_test` fixes the issue.
