### PR TITLE
Add revoked check as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ type Options struct {
   // A function that extracts the token from the request
   // Default: FromAuthHeader (i.e., from Authorization header as bearer token)
   Extractor TokenExtractor
+  // A function that checks if the token was revoked.
+  // Default value: nil
+  CheckRevoked RevokedChecker
   // Debug flag turns on debugging output
   // Default: false  
   Debug bool
@@ -172,6 +175,21 @@ jwtmiddleware.New(jwtmiddleware.Options{
                                      jwtmiddleware.FromParameter("auth_code")),
 })
 ```
+
+### Check Revoked
+
+The default value for the `CheckRevoked` option is `nil`, but sometimes it is necessary to check
+wether a token is revoked or not, e.g.,
+
+```go
+jwtmiddleware.New(jwtmiddleware.Options{
+  CheckRevoked: func (token *jwt.Token) (bool, error) {
+    isRevoked := someFunc(token)
+    return isRevoked, nil
+  },
+})
+```
+
 
 ## Examples
 

--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -241,16 +241,17 @@ func (m *JWTMiddleware) CheckJWT(w http.ResponseWriter, r *http.Request) error {
 
 	if m.Options.CheckRevoked != nil {
 		revoked, err := m.Options.CheckRevoked(parsedToken)
-		if revoked {
-			errorMsg := "Token was revoked"
-			m.Options.ErrorHandler(w, r, errorMsg)
-			m.logf(errorMsg)
-			return fmt.Errorf(errorMsg)
-		}
 
 		if err != nil {
 			errorMsg := fmt.Sprintf("Error checking revocation: %s", err.Error())
 			m.Options.ErrorHandler(w, r, err.Error())
+			m.logf(errorMsg)
+			return fmt.Errorf(errorMsg)
+		}
+
+		if revoked {
+			errorMsg := "Token was revoked"
+			m.Options.ErrorHandler(w, r, errorMsg)
 			m.logf(errorMsg)
 			return fmt.Errorf(errorMsg)
 		}


### PR DESCRIPTION
This pull request adds a middleware function to the options. This function is optional and will be used to check if a token was revoked. It is basically like the `isRevoked` callback in [express-jwt](https://github.com/auth0/express-jwt)