### PR TITLE
Allow for custom context handlers.

### DIFF
--- a/jwtmiddleware_test.go
+++ b/jwtmiddleware_test.go
@@ -46,10 +46,6 @@ func TestUnauthenticatedRequest(t *testing.T) {
 	})
 }
 
-// TestCustomContextSetter will test setting a custom context setter
-func TestCustomContextSetter(t *testing.T) {
-}
-
 // TestUnauthenticatedRequest will perform requests with no Authorization header
 func TestAuthenticatedRequest(t *testing.T) {
 	var e error


### PR DESCRIPTION
I am using [go-kit](https://github.com/go-kit/kit) and it uses [net/context](https://godoc.org/golang.org/x/net/context) throughout. I didn't want to add a dependency of gorilla/context just to implement the JWT decoding. This change allows us to provide a custom context setter that can set whatever context is used.

I had to make a few changes to the test structure to get it implemented in the easiest way.
