### PR TITLE
Replace "github.com/codegangsta/negroni"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ import (
   "net/http"
 
   "github.com/auth0/go-jwt-middleware"
-  "github.com/codegangsta/negroni"
+  "github.com/urfave/negroni"
   "github.com/dgrijalva/jwt-go"
   "github.com/gorilla/context"
   "github.com/gorilla/mux"

--- a/examples/negroni-example/main.go
+++ b/examples/negroni-example/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"github.com/auth0/go-jwt-middleware"
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/mux"
 	"net/http"

--- a/jwtmiddleware_test.go
+++ b/jwtmiddleware_test.go
@@ -3,11 +3,11 @@ package jwtmiddleware
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/urfave/negroni"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/urfave/negroni"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"

--- a/jwtmiddleware_test.go
+++ b/jwtmiddleware_test.go
@@ -3,7 +3,7 @@ package jwtmiddleware
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/context"
 	"github.com/gorilla/mux"


### PR DESCRIPTION
Replace "github.com/codegangsta/negroni" with "github.com/urfave/negroni"
As "codegangsta/negroni" redirects to "urfave/negroni", and pointed out in that project's README