### PR TITLE
Can no longer range over Claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ var myHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
   user := context.Get(r, "user")
   fmt.Fprintf(w, "This is an authenticated request")
   fmt.Fprintf(w, "Claim content:\n")
-  for k, v := range user.(*jwt.Token).Claims {
+  for k, v := range user.(*jwt.Token).Claims.(jwt.MapClaims) {
     fmt.Fprintf(w, "%s :\t%#v\n", k, v)
   }
 })
@@ -78,7 +78,7 @@ var myHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
   user := r.Context().Value("user");
   fmt.Fprintf(w, "This is an authenticated request")
   fmt.Fprintf(w, "Claim content:\n")
-  for k, v := range user.(*jwt.Token).Claims {
+  for k, v := range user.(*jwt.Token).Claims.(jwt.MapClaims) {
     fmt.Fprintf(w, "%s :\t%#v\n", k, v)
   }
 })


### PR DESCRIPTION
https://github.com/dgrijalva/jwt-go/blob/master/MIGRATION_GUIDE.md

Token.Claims is now an interface type:
Claims replaces map[string]interface{}.
Concrete implementations of Claims includes MapClaims

Also recognized in #20 