### PR TITLE
allow JWT properties to be stored under non-string context key

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ type Options struct {
   // It can be either a shared secret or a public key.
   // Default value: nil
   ValidationKeyGetter jwt.Keyfunc
-  // The name of the property in the request where the user information
+  // The key for the value stored in the request's context where the user information
   // from the JWT will be stored.
   // Default value: "user"
   UserProperty string

--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -26,10 +26,10 @@ type Options struct {
 	// It can be either a shared secret or a public key.
 	// Default value: nil
 	ValidationKeyGetter jwt.Keyfunc
-	// The name of the property in the request where the user information
+	// The key for the value stored in the request's context where the user information
 	// from the JWT will be stored.
 	// Default value: "user"
-	UserProperty string
+	UserProperty interface{}
 	// The function that will be called when there's an error validating the token
 	// Default value:
 	ErrorHandler errorHandler
@@ -70,7 +70,7 @@ func New(options ...Options) *JWTMiddleware {
 		opts = options[0]
 	}
 
-	if opts.UserProperty == "" {
+	if opts.UserProperty == nil {
 		opts.UserProperty = "user"
 	}
 


### PR DESCRIPTION
## What
- This PR changes the property key to be used in request context to `interface{}`
- Changes are backwards compatible, because string satisfies `interface{}`

## Why

Storing context values with string keys is not a clean design. A conflict may arise if other package were to add a 'user' value to the context. A solution is to use predefined package's private context keys. The problem and way of creating such keys are both described [here](https://medium.com/golangspec/globally-unique-key-for-context-value-in-golang-62026854b48f).

This PR enables that behaviour.