### PR TITLE
Make errorHandler take error instead of string

### DIFF
--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -32,7 +32,7 @@ type Options struct {
 	// Default value: "user"
 	UserProperty string
 	// The function that will be called when there's an error validating the token
-	// Default value:
+	// Default value: OnError
 	ErrorHandler errorHandler
 	// A boolean indicating if the credentials are required or not
 	// Default value: false


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Make error handler take an `error` instead of a string. This is a much more powerful API, especially since [Go 1.13](https://blog.golang.org/go1.13-errors), as nested errors can now be extracted. I didn't introduce any `%w` wrapped errors as I wasn't sure which versions of Go you support.

**This is technically a breaking change**, as it changes the accepted values given to `ErrorHandler` in the `Options` struct. I did notice that there hasn't been v1 release of this package yet (technically `v0.0.0-whatever` still as reported in `go.mod`) so I'm raising this PR in the hope that breaking changes are still accepted.

Changes error messages to [start with a lower case character](https://github.com/golang/go/wiki/CodeReviewComments#error-strings).

Added missing note about what the default value is for `ErrorHandler`

### References

Fixes #52.

### Testing

Change can be tested by using the package as described and passing in an `Extractor` in Options that always returns an error.
Tests pass on my local MBP dev machine.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
  - I have not checked the docs on auth0.com/docs.
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
