### PR TITLE
Wrap errors with %w instead of %v

### DIFF
--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -181,7 +181,7 @@ func (m *JWTMiddleware) CheckJWT(w http.ResponseWriter, r *http.Request) error {
 	// If an error occurs, call the error handler and return an error
 	if err != nil {
 		m.Options.ErrorHandler(w, r, err.Error())
-		return fmt.Errorf("Error extracting token: %v", err)
+		return fmt.Errorf("Error extracting token: %w", err)
 	}
 
 	// If the token is empty...
@@ -207,7 +207,7 @@ func (m *JWTMiddleware) CheckJWT(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		m.logf("Error parsing token: %v", err)
 		m.Options.ErrorHandler(w, r, err.Error())
-		return fmt.Errorf("Error parsing token: %v", err)
+		return fmt.Errorf("Error parsing token: %w", err)
 	}
 
 	if m.Options.SigningMethod != nil && m.Options.SigningMethod.Alg() != parsedToken.Header["alg"] {


### PR DESCRIPTION
### Description
Wrap errors using `%w` instead of `%v`. This allows handling errors based on the internal errors with `errors.Is` and `errors.As`, as explained [here](https://blog.golang.org/go1.13-errors). This feature has been introduced in Go 1.13 and is back-compatible and as this repo already uses Go 1.14 it should not introduce breaking changes.

This allows returning different error types in the `ValidationKeyGetter` function and then use them in the error returned by `CheckJWT`. For example:

```go
type MyCustomError struct {
	error       string
	serverError bool
}

// Implement error interface
func (e MyCustomError) Error() string {
	return e.error
}

func main() {
	mw := jwtmiddleware.New(jwtmiddleware.Options{
		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err string) {
			// ...
		},
		ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
			if somethingUnexpectedHappened() {
				return nil, MyCustomError{error: "Server error", serverError: true}
			}

			if badRequest() {
				return nil, MyCustomError{error: "Bad request", serverError: false}
			}

			// ...

			return publicKey, nil
		},
		SigningMethod: jwt.SigningMethodRS256,
	})

	err := mw.CheckJWT(...)
	if err != nil {
		var myCustomError MyCustomError
		
		if errors.As(err, &myCustomError) {
			if myCustomError.serverError {
				// Return HTTP 500 Internal Server Error
			}

			// Return HTTP 401 Unauthorized
		}

		// Default: Return HTTP 500 Internal Server Error
	}
}
```

### References

 - Working with Errors in Go 1.13: https://blog.golang.org/go1.13-errors

### Testing

No tests have been added because:
 - There doesn't currently seem to be tests testing this low-level type of thing at the moment.
 - It's non-breaking change that doesn't change the behaviour, unless `errors.Is` or `errors.As` are used.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`