### PR TITLE
Update how to handle jwtMiddleware in martini

### DIFF
--- a/examples/martini-example/main.go
+++ b/examples/martini-example/main.go
@@ -26,7 +26,9 @@ func StartServer() {
 	})
 
 	m.Get("/ping", PingHandler)
-	m.Get("/secured/ping", jwtMiddleware.CheckJWT, SecuredPingHandler)
+	m.Get("/secured/ping", func(w http.ResponseWriter, r *http.Request) {
+		jwtMiddleware.CheckJWT(w, r)
+	}, SecuredPingHandler)
 
 	m.Run()
 }


### PR DESCRIPTION
### Description

> FIx returning invalid response text/plain `<invalid Value>` instead of application/json `{ "text": "All good. You only get this message if you're authenticated"}` when hit endpoint `/secured/ping`, how to fix this issue is by wrapping `jwtMiddleware.CheckJWT` with a function that requires params request and response that injected by Martini.

### References

> Include any links supporting this change such as a:
>
> - Issue [https://github.com/auth0/go-jwt-middleware/issues/17](url)
> - [https://github.com/go-martini/martini#service-injection](url)

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
