### PR TITLE
update broken blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ func main() {
     },
     // When set, the middleware verifies that tokens are signed with the specific signing algorithm
     // If the signing method is not constant the ValidationKeyGetter callback can be used to implement additional checks
-    // Important to avoid security issues described here: https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+    // Important to avoid security issues described here: https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
     SigningMethod: jwt.SigningMethodHS256,
   })
 
@@ -94,7 +94,7 @@ func main() {
     },
     // When set, the middleware verifies that tokens are signed with the specific signing algorithm
     // If the signing method is not constant the ValidationKeyGetter callback can be used to implement additional checks
-    // Important to avoid security issues described here: https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+    // Important to avoid security issues described here: https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
     SigningMethod: jwt.SigningMethodHS256,
   })
 
@@ -136,7 +136,7 @@ type Options struct {
   EnableAuthOnOptions bool,
   // When set, the middelware verifies that tokens are signed with the specific signing algorithm
   // If the signing method is not constant the ValidationKeyGetter callback can be used to implement additional checks
-  // Important to avoid security issues described here: https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+  // Important to avoid security issues described here: https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
   // Default: nil
   SigningMethod jwt.SigningMethod
 }

--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -48,7 +48,7 @@ type Options struct {
 	EnableAuthOnOptions bool
 	// When set, the middelware verifies that tokens are signed with the specific signing algorithm
 	// If the signing method is not constant the ValidationKeyGetter callback can be used to implement additional checks
-	// Important to avoid security issues described here: https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+	// Important to avoid security issues described here: https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
 	// Default: nil
 	SigningMethod jwt.SigningMethod
 }


### PR DESCRIPTION
The blog link for https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/ is broken as reported by #82. This PR fixes the link.