### PR TITLE
add cookie token extractor for v2

### DIFF
--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -169,6 +169,23 @@ func AuthHeaderTokenExtractor(r *http.Request) (string, error) {
 	return authHeaderParts[1], nil
 }
 
+// CookieTokenExtractor builds a TokenExtractor that takes a request and
+// extracts the token from the cookie using the passed in cookieName.
+func CookieTokenExtractor(cookieName string) TokenExtractor {
+	return func(r *http.Request) (string, error) {
+		cookie, err := r.Cookie(cookieName)
+		if err != nil {
+			return "", err
+		}
+
+		if cookie != nil {
+			return cookie.Value, nil
+		}
+
+		return "", nil // No error, just no JWT
+	}
+}
+
 // ParameterTokenExtractor returns a TokenExtractor that extracts the token
 // from the specified query string parameter
 func ParameterTokenExtractor(param string) TokenExtractor {

--- a/jwtmiddleware_test.go
+++ b/jwtmiddleware_test.go
@@ -310,6 +310,47 @@ func Test_AuthHeaderTokenExtractor(t *testing.T) {
 	}
 }
 
+func Test_CookieTokenExtractor(t *testing.T) {
+	tests := []struct {
+		name      string
+		cookie    *http.Cookie
+		wantToken string
+		wantError string
+	}{
+		{
+			name:      "no cookie",
+			wantError: "http: named cookie not present",
+		},
+		{
+			name:      "token in cookie",
+			cookie:    &http.Cookie{Name: "token", Value: "i-am-token"},
+			wantToken: "i-am-token",
+		},
+		{
+			name:   "empty cookie",
+			cookie: &http.Cookie{Name: "token"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+			if tc.cookie != nil {
+				req.AddCookie(tc.cookie)
+			}
+
+			gotToken, gotError := CookieTokenExtractor("token")(req)
+			mustErrorMsg(t, tc.wantError, gotError)
+
+			if tc.wantToken != gotToken {
+				t.Fatalf("wanted token: %q, got: %q", tc.wantToken, gotToken)
+			}
+
+		})
+	}
+}
+
 func mustErrorMsg(t testing.TB, want string, got error) {
 	if (want == "" && got != nil) ||
 		(want != "" && (got == nil || got.Error() != want)) {


### PR DESCRIPTION
This PR adds a cookie token extractor for v2. It borrows heavily from the work done in #10.

It's quite simple - it allows you to specify a cookie name and then will pull the token from there.