### PR TITLE
Isolate example-only dependencies

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,0 +1,14 @@
+module github.com/auth0/go-jwt-middleware/examples
+
+go 1.14
+
+require (
+	github.com/auth0/go-jwt-middleware v0.0.0
+	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
+	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
+	github.com/gorilla/mux v1.7.4
+	github.com/urfave/negroni v1.0.0
+)
+
+replace github.com/auth0/go-jwt-middleware => ../

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,5 +1,9 @@
+github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+BukdIpxwO365v/Rbspp2Nt5XntgQRXq8Q=
+github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab h1:xveKWz2iaueeTaUgdetzel+U7exyigDYBryyVfV/rZk=
+github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 h1:l5lAOZEym3oK3SQ2HBHWsJUfbNBiTXJDeW2QDxw9AQ0=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,7 @@ module github.com/auth0/go-jwt-middleware
 go 1.14
 
 require (
-	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
-	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
 	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/smartystreets/assertions v1.1.0 // indirect


### PR DESCRIPTION
### Description

Add a separate go.mod file specifically for the examples package and tidy the top-level go.mod file to avoid propagating unnecessary dependencies on unmaintained transitive modules.

Spotted when switching to this module in https://github.com/kubernetes/kubernetes/pull/102755#discussion_r655677449