### PR TITLE
feat: add JWKS provider to the josev2 validator 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,13 +11,13 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: install go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.16
       - name: checkout code
         uses: actions/checkout@v2
       - name: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: install go

--- a/examples/http-example/main.go
+++ b/examples/http-example/main.go
@@ -26,6 +26,15 @@ var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 })
 
 func main() {
+	// uncomment the below to use the caching key provider
+	// u, err := url.Parse("https://<your-domain>")
+	// if err != nil {
+	// 	// we'll panic in order to fail fast
+	// 	panic(err)
+	// }
+
+	// p := josev2.NewCachingJWKSProvider(*u, 5*time.Minute)
+
 	keyFunc := func(ctx context.Context) (interface{}, error) {
 		// our token must be signed using this data
 		return []byte("secret"), nil
@@ -41,6 +50,7 @@ func main() {
 
 	// setup the piece which will validate tokens
 	validator, err := josev2.New(
+		// p.KeyFunc, // uncomment this to use the caching key provider
 		keyFunc,
 		jose.HS256,
 		josev2.WithExpectedClaims(expectedClaimsFunc),

--- a/examples/http-jwks-example/README.md
+++ b/examples/http-jwks-example/README.md
@@ -1,0 +1,15 @@
+# HTTP JWKS example
+
+This is an example of how to use the http middleware with JWKS.
+
+# Using it
+
+To try this out:
+1. Install all dependencies with `go install`
+1. Go to https://manage.auth0.com/ and create a new API.
+1. Go to the "Test" tab of the API and copy the cURL example.
+1. Run the cURL example in your terminal and copy the `access_token` from the response. The tool jq can be helpful for this.
+1. In the example change `<your tenant domain>` on line 29 to the domain used in the cURL request.
+1. Run the example with `go run main.go`.
+1. In a new terminal use cURL to talk to the API: `curl -v --request GET --url http://localhost:3000`
+1. Now try it again with the `access_token` you copied earlier and run `curl -v --request GET --url http://localhost:3000 --header "authorization: Bearer $TOKEN"` to see a successful request.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/golang-jwt/jwt v3.2.1+incompatible
-	github.com/google/go-cmp v0.5.5
+	github.com/google/go-cmp v0.5.6
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfE
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/oidc/oidc.go
+++ b/internal/oidc/oidc.go
@@ -1,0 +1,39 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+)
+
+// WellKnownEndpoints holds the well known OIDC endpoints
+type WellKnownEndpoints struct {
+	JWKSURI string `json:"jwks_uri"`
+}
+
+// GetWellKnownEndpointsFromIssuerURL gets the well known endpoints for the
+// passed in issuer url
+func GetWellKnownEndpointsFromIssuerURL(ctx context.Context, issuerURL url.URL) (*WellKnownEndpoints, error) {
+	issuerURL.Path = path.Join(issuerURL.Path, ".well-known/openid-configuration")
+
+	req, err := http.NewRequest(http.MethodGet, issuerURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not build request to get well known endpoints: %w", err)
+	}
+	req = req.WithContext(ctx)
+
+	r, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not get well known endpoints from url %s: %w", issuerURL.String(), err)
+	}
+	var wkEndpoints WellKnownEndpoints
+	err = json.NewDecoder(r.Body).Decode(&wkEndpoints)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode json body when getting well known endpoints: %w", err)
+	}
+
+	return &wkEndpoints, nil
+}

--- a/validate/josev2/examples/README.md
+++ b/validate/josev2/examples/README.md
@@ -81,5 +81,7 @@ It will print out something like
 The token isn't valid: expected claims not validated: square/go-jose/jwt: validation failed, invalid issuer claim (iss)
 ```
 
+### JWKS
+For a JWKS example please see [examples/http-jwks-example/README.md](../../../examples/http-jwks-example/README.md).
 
 Take a look through the example code and things will make a lot more sense.

--- a/validate/josev2/josev2_test.go
+++ b/validate/josev2/josev2_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/auth0/go-jwt-middleware/internal/oidc"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -224,8 +223,18 @@ func Test_JWKSProvider(t *testing.T) {
 					t.Fatalf("did not want an error, but got %s", err)
 				}
 
-				if want, got := &jwks, actualJWKS; !cmp.Equal(want, got, cmpopts.IgnoreUnexported()) {
-					t.Fatalf("jwks did not match: %s", cmp.Diff(want, got, cmpopts.IgnoreUnexported()))
+				jwksJSON, err := json.Marshal(jwks)
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+
+				actualJWKSJSON, err := json.Marshal(actualJWKS)
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+
+				if want, got := jwksJSON, actualJWKSJSON; !cmp.Equal(want, got) {
+					t.Fatalf("jwks did not match: %s", cmp.Diff(want, got))
 				}
 
 				if want, got := &jwks, p.cache[serverURL.Hostname()].jwks; !cmp.Equal(want, got) {

--- a/validate/josev2/josev2_test.go
+++ b/validate/josev2/josev2_test.go
@@ -223,17 +223,7 @@ func Test_JWKSProvider(t *testing.T) {
 					t.Fatalf("did not want an error, but got %s", err)
 				}
 
-				jwksJSON, err := json.Marshal(jwks)
-				if !equalErrors(err, "") {
-					t.Fatalf("did not want an error, but got %s", err)
-				}
-
-				actualJWKSJSON, err := json.Marshal(actualJWKS)
-				if !equalErrors(err, "") {
-					t.Fatalf("did not want an error, but got %s", err)
-				}
-
-				if want, got := jwksJSON, actualJWKSJSON; !cmp.Equal(want, got) {
+				if want, got := &jwks, actualJWKS; !cmp.Equal(want, got) {
 					t.Fatalf("jwks did not match: %s", cmp.Diff(want, got))
 				}
 

--- a/validate/josev2/josev2_test.go
+++ b/validate/josev2/josev2_test.go
@@ -2,9 +2,20 @@ package josev2
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
 	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/auth0/go-jwt-middleware/internal/oidc"
 	"github.com/google/go-cmp/cmp"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
@@ -51,7 +62,7 @@ func Test_Validate(t *testing.T) {
 			name:               "errors on wrong algorithm",
 			signatureAlgorithm: jose.PS256,
 			token:              `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o`,
-			expectedError:      "expected \"PS256\" signin algorithm but token specified \"HS256\"",
+			expectedError:      "expected \"PS256\" signing algorithm but token specified \"HS256\"",
 		},
 		{
 			name:          "errors when jwt.ParseSigned errors",
@@ -153,4 +164,266 @@ func Test_New(t *testing.T) {
 		}
 	})
 
+}
+
+func Test_JWKSProvider(t *testing.T) {
+	var (
+		p                            CachingJWKSProvider
+		server                       *httptest.Server
+		responseBytes                []byte
+		responseStatusCode, reqCount int
+		serverURL                    *url.URL
+	)
+
+	tests := []struct {
+		name string
+		main func(t *testing.T)
+	}{
+		{
+			name: "calls out to well known endpoint",
+			main: func(t *testing.T) {
+				_, jwks := genValidRSAKeyAndJWKS(t)
+				var err error
+				responseBytes, err = json.Marshal(jwks)
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+
+				_, err = p.KeyFunc(context.TODO())
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+			},
+		},
+		{
+			name: "errors if it can't decode the jwks",
+			main: func(t *testing.T) {
+				responseBytes = []byte("<>")
+				_, err := p.KeyFunc(context.TODO())
+
+				wantErr := "could not decode jwks: invalid character '<' looking for beginning of value"
+				if !equalErrors(err, wantErr) {
+					t.Fatalf("wanted err:\n%s\ngot:\n%+v\n", wantErr, err)
+				}
+			},
+		},
+		{
+			name: "passes back the valid jwks",
+			main: func(t *testing.T) {
+				_, jwks := genValidRSAKeyAndJWKS(t)
+				var err error
+				responseBytes, err = json.Marshal(jwks)
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+
+				p.CacheTTL = time.Minute * 5
+				actualJWKS, err := p.KeyFunc(context.TODO())
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+
+				if want, got := &jwks, actualJWKS; !cmp.Equal(want, got) {
+					t.Fatalf("jwks did not match: %s", cmp.Diff(want, got))
+				}
+
+				if want, got := &jwks, p.cache[serverURL.Hostname()].jwks; !cmp.Equal(want, got) {
+					t.Fatalf("cached jwks did not match: %s", cmp.Diff(want, got))
+				}
+
+				expiresAt := p.cache[serverURL.Hostname()].expiresAt
+				if !time.Now().Before(expiresAt) {
+					t.Fatalf("wanted cache item expiration to be in the future but it was not: %s", expiresAt)
+				}
+			},
+		},
+		{
+			name: "returns the cached jwks when they are not expired",
+			main: func(t *testing.T) {
+				_, expectedCachedJWKS := genValidRSAKeyAndJWKS(t)
+				p.cache[serverURL.Hostname()] = cachedJWKS{
+					jwks:      &expectedCachedJWKS,
+					expiresAt: time.Now().Add(1 * time.Minute),
+				}
+
+				actualJWKS, err := p.KeyFunc(context.TODO())
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+
+				if want, got := &expectedCachedJWKS, actualJWKS; !cmp.Equal(want, got) {
+					t.Fatalf("cached jwks did not match: %s", cmp.Diff(want, got))
+				}
+
+				if reqCount > 0 {
+					t.Fatalf("did not want any requests since we should have read from the cache, but we got %d requests", reqCount)
+				}
+			},
+		},
+		{
+			name: "re-caches the jwks if they have expired",
+			main: func(t *testing.T) {
+				_, expiredCachedJWKS := genValidRSAKeyAndJWKS(t)
+				expiresAt := time.Now().Add(-10 * time.Minute)
+				p.cache[server.URL] = cachedJWKS{
+					jwks:      &expiredCachedJWKS,
+					expiresAt: expiresAt,
+				}
+				_, jwks := genValidRSAKeyAndJWKS(t)
+				var err error
+				responseBytes, err = json.Marshal(jwks)
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+
+				p.CacheTTL = time.Minute * 5
+				actualJWKS, err := p.KeyFunc(context.TODO())
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+
+				if want, got := &jwks, actualJWKS; !cmp.Equal(want, got) {
+					t.Fatalf("jwks did not match: %s", cmp.Diff(want, got))
+				}
+
+				if want, got := &jwks, p.cache[serverURL.Hostname()].jwks; !cmp.Equal(want, got) {
+					t.Fatalf("cached jwks did not match: %s", cmp.Diff(want, got))
+				}
+
+				cacheExpiresAt := p.cache[serverURL.Hostname()].expiresAt
+				if !time.Now().Before(cacheExpiresAt) {
+					t.Fatalf("wanted cache item expiration to be in the future but it was not: %s", cacheExpiresAt)
+				}
+			},
+		},
+		{
+			name: "only calls the API once when multiple requests come in",
+			main: func(t *testing.T) {
+				_, jwks := genValidRSAKeyAndJWKS(t)
+				var err error
+				responseBytes, err = json.Marshal(jwks)
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+
+				p.CacheTTL = time.Minute * 5
+
+				wg := sync.WaitGroup{}
+				for i := 0; i < 50; i++ {
+					wg.Add(1)
+					go func(t *testing.T) {
+						actualJWKS, err := p.KeyFunc(context.TODO())
+						if !equalErrors(err, "") {
+							t.Errorf("did not want an error, but got %s", err)
+						}
+
+						if want, got := &jwks, actualJWKS; !cmp.Equal(want, got) {
+							t.Errorf("jwks did not match: %s", cmp.Diff(want, got))
+						}
+
+						wg.Done()
+					}(t)
+				}
+				wg.Wait()
+
+				actualJWKS, err := p.KeyFunc(context.TODO())
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+
+				if want, got := &jwks, actualJWKS; !cmp.Equal(want, got) {
+					t.Fatalf("jwks did not match: %s", cmp.Diff(want, got))
+				}
+
+				if reqCount != 2 {
+					t.Fatalf("only wanted 2 requests (well known and jwks) , but we got %d requests", reqCount)
+				}
+
+				if want, got := &jwks, p.cache[serverURL.Hostname()].jwks; !cmp.Equal(want, got) {
+					t.Fatalf("cached jwks did not match: %s", cmp.Diff(want, got))
+				}
+
+				cacheExpiresAt := p.cache[serverURL.Hostname()].expiresAt
+				if !time.Now().Before(cacheExpiresAt) {
+					t.Fatalf("wanted cache item expiration to be in the future but it was not: %s", cacheExpiresAt)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		var reqCallMutex sync.Mutex
+
+		reqCount = 0
+		responseBytes = []byte(`{"kid":""}`)
+		responseStatusCode = http.StatusOK
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// handle mutex things
+			reqCallMutex.Lock()
+			defer reqCallMutex.Unlock()
+			reqCount++
+			w.WriteHeader(responseStatusCode)
+
+			switch r.URL.String() {
+			case "/.well-known/openid-configuration":
+				wk := oidc.WellKnownEndpoints{JWKSURI: server.URL + "/url_for_jwks"}
+				json.NewEncoder(w).Encode(wk)
+			case "/url_for_jwks":
+				_, err := w.Write(responseBytes)
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
+			default:
+				t.Fatalf("do not know how to handle url %s", r.URL.String())
+			}
+
+		}))
+		defer server.Close()
+		serverURL = mustParseURL(server.URL)
+
+		p = CachingJWKSProvider{
+			IssuerURL: *serverURL,
+			CacheTTL:  0,
+			cache:     map[string]cachedJWKS{},
+		}
+
+		t.Run(test.name, test.main)
+	}
+}
+
+func mustParseURL(toParse string) *url.URL {
+	parsed, err := url.Parse(toParse)
+	if err != nil {
+		panic(err)
+	}
+
+	return parsed
+}
+
+func genValidRSAKeyAndJWKS(t *testing.T) (*rsa.PrivateKey, jose.JSONWebKeySet) {
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(1653),
+	}
+	priv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	rawCert, err := x509.CreateCertificate(rand.Reader, ca, ca, &priv.PublicKey, priv)
+	if !equalErrors(err, "") {
+		t.Fatalf("did not want an error, but got %s", err)
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				Key:   priv,
+				KeyID: "kid",
+				Certificates: []*x509.Certificate{
+					{
+						Raw: rawCert,
+					},
+				},
+				CertificateThumbprintSHA1:   []uint8{},
+				CertificateThumbprintSHA256: []uint8{},
+			},
+		},
+	}
+	return priv, jwks
 }

--- a/validate/josev2/josev2_test.go
+++ b/validate/josev2/josev2_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/auth0/go-jwt-middleware/internal/oidc"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -223,8 +224,8 @@ func Test_JWKSProvider(t *testing.T) {
 					t.Fatalf("did not want an error, but got %s", err)
 				}
 
-				if want, got := &jwks, actualJWKS; !cmp.Equal(want, got) {
-					t.Fatalf("jwks did not match: %s", cmp.Diff(want, got))
+				if want, got := &jwks, actualJWKS; !cmp.Equal(want, got, cmpopts.IgnoreUnexported()) {
+					t.Fatalf("jwks did not match: %s", cmp.Diff(want, got, cmpopts.IgnoreUnexported()))
 				}
 
 				if want, got := &jwks, p.cache[serverURL.Hostname()].jwks; !cmp.Equal(want, got) {

--- a/validate/josev2/josev2_test.go
+++ b/validate/josev2/josev2_test.go
@@ -367,7 +367,10 @@ func Test_JWKSProvider(t *testing.T) {
 			switch r.URL.String() {
 			case "/.well-known/openid-configuration":
 				wk := oidc.WellKnownEndpoints{JWKSURI: server.URL + "/url_for_jwks"}
-				json.NewEncoder(w).Encode(wk)
+				err := json.NewEncoder(w).Encode(wk)
+				if !equalErrors(err, "") {
+					t.Fatalf("did not want an error, but got %s", err)
+				}
 			case "/url_for_jwks":
 				_, err := w.Write(responseBytes)
 				if !equalErrors(err, "") {


### PR DESCRIPTION
Many times JWTs will be signed with a JWKS. When working with JWKS it is beneficial to cache the keys used to check token in order to decrease request round-trip and keep from potentially hitting identity provider rate limits. This PR adds a JWKS provider to the josev2 validator as well as a caching JWKS provider.