### PR TITLE
SDK-2885 Display error messages in the response when validation fails when using DefaultErrorHandler

### DIFF
--- a/error_handler.go
+++ b/error_handler.go
@@ -27,13 +27,18 @@ type ErrorHandler func(w http.ResponseWriter, r *http.Request, err error)
 // middleware. If an error handler is not provided via the WithErrorHandler
 // option this will be used.
 func DefaultErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	w.Header().Set("Content-Type", "application/json")
+
 	switch {
 	case errors.Is(err, ErrJWTMissing):
 		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"JWT is missing."}`))
 	case errors.Is(err, ErrJWTInvalid):
 		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"JWT is invalid."}`))
 	default:
 		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"Something went wrong while checking the JWT."}`))
 	}
 }
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

In this PR we add the ability to display back an error message in json format to the caller when using the DefaultErrorHandler.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
