### PR TITLE
Allow setting a custom http.Client on the provider

### DIFF
--- a/jwks/provider.go
+++ b/jwks/provider.go
@@ -51,6 +51,13 @@ func WithCustomJWKSURI(jwksURI *url.URL) ProviderOption {
 	}
 }
 
+// WithCustomClient will set a custom *http.Client on the *Provider
+func WithCustomClient(c *http.Client) ProviderOption {
+	return func(p *Provider) {
+		p.Client = c
+	}
+}
+
 // KeyFunc adheres to the keyFunc signature that the Validator requires.
 // While it returns an interface to adhere to keyFunc, as long as the
 // error is nil the type will be *jose.JSONWebKeySet.

--- a/jwks/provider_test.go
+++ b/jwks/provider_test.go
@@ -62,6 +62,16 @@ func Test_JWKSProvider(t *testing.T) {
 		}
 	})
 
+	t.Run("It uses the specified custom client", func(t *testing.T) {
+		client := &http.Client{
+			Timeout: time.Hour, // unused value. We only need this to have a client different than the default
+		}
+		provider := NewProvider(testServerURL, WithCustomClient(client))
+		if !cmp.Equal(client, provider.Client) {
+			t.Fatalf("expected custom client %#v to be configured. Got: %#v", client, provider.Client)
+		}
+	})
+
 	t.Run("It tells the provider to cancel fetching the JWKS if request is cancelled", func(t *testing.T) {
 		ctx := context.Background()
 		ctx, cancel := context.WithTimeout(ctx, 0)
@@ -134,7 +144,7 @@ func Test_JWKSProvider(t *testing.T) {
 	t.Run(
 		"It fails to parse the jwks uri after fetching it from the discovery endpoint if malformed",
 		func(t *testing.T) {
-			malformedURL, err := url.Parse(testServer.URL+"/malformed")
+			malformedURL, err := url.Parse(testServer.URL + "/malformed")
 			require.NoError(t, err)
 
 			provider := NewProvider(malformedURL)


### PR DESCRIPTION
## Description

This allows setting a custom http.Client for the provider.

I am using this library in a side project, and I want to write tests for my provider setup. But I can't run mock requests, as [httptest.NewTLSServer](https://pkg.go.dev/net/http/httptest#NewTLSServer) uses self-signed certificates.
Using a custom client here will allow me to allow the self-signed certificate in my tests.


## Testing

This is unit-tested.


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `master`.
