### PR TITLE
Update Codecov

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,11 +2,11 @@ name: test
 on:
   push:
     branches:
-      - 'master'
+      - "master"
   pull_request:
     type: [created, synchronize, reopened]
     branches:
-      - '*'
+      - "*"
 jobs:
   test:
     strategy:
@@ -23,7 +23,7 @@ jobs:
       - name: test
         run: make test
       - name: upload coverage to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: coverage.out
           fail_ci_if_error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,6 @@ jobs:
       - name: upload coverage to codecov
         uses: codecov/codecov-action@v3
         with:
-          file: coverage.out
+          files: coverage.out
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
This PR bumps the Codecov GitHub Action to v3 from v1, as that version had been deprecated.