### PR TITLE
Remove vulncheck step from lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,9 +21,6 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
-      - name: Check for go vulnerabilities
-        run: make check-vuln
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
### 🔧 Changes

We no longer need to run this in the lint workflow as it has its own dedicated workflow

