### PR TITLE
Remove vulncheck version in govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,6 +17,5 @@ jobs:
         uses: Templum/govulncheck-action@main
         with:
           go-version: 1.19
-          vulncheck-version: latest
           package: ./...
           fail-on-vuln: true


### PR DESCRIPTION
### 🔧 Changes

There is a compatibility issue between `Templum/govulncheck-action` and the latest `govulncheck` json format. This has been "fixed" for now in `Templum/govulncheck-action  by setting the default version of `govulncheck` to a known working version, but by supplying `"latest"` we're overriding this fix. So for now don't set a `govulncheck` version.

This PR will most likely fail too as we're using `pull_request_target` which runs the action based on the workflow defined in the base of this PR rather than from the PR

