### PR TITLE
chore: Add `.semgrepignore` exclusion manifest

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,2 @@
+examples/
+*.md


### PR DESCRIPTION
This PR adds a `.semgrepignore` manifest file and excludes Markdown files and all files under the `examples` directory. This resolves several false positive warnings from Semgrep.