### PR TITLE
chore(security): Pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   scan:
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@main
       - name: Scan for Vulnerabilities in Code
-        uses: Templum/govulncheck-action@main
+        uses: Templum/govulncheck-action@435a35e28c7e56076f6daf838b81c1aa76ee0c95 # pin@0.10.1
         with:
           go-version: 1.19
           package: ./...

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
           check-latest: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # pin@3.6.0
         with:
           args: -v --timeout=5m
           skip-build-cache: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
         run: make test
 
       - name: upload coverage to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # pin@3.1.4
         with:
           files: coverage.out
           fail_ci_if_error: false


### PR DESCRIPTION
This PR pins the `Templum/govulncheck-action`, `golangci/golangci-lint-action`, and `codecov/codecov-action` third-party actions to the full-length commit SHAs for their most recent releases.

Pinning an action to a full-length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository. [docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)