### PR TITLE
ESD-32688: Improve locking and blocking associated with key retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+.DS_Store
 
 # Test binary, built with `go test -c`
 *.test

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/sync v0.5.0
 	gopkg.in/go-jose/go-jose.v2 v2.6.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.4.0 h1:UVQgzMY87xqpKNgb+kDsll2Igd33HszWHFLmpaRMq/8=
 golang.org/x/crypto v0.4.0/go.mod h1:3quD/ATkf6oY+rnes5c3ExXTbLc8mueNue5/DoinL80=
+golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/go-jose/go-jose.v2 v2.6.1 h1:qEzJlIDmG9q5VO0M/o8tGS65QMHMS1w01TQJB1VPJ4U=


### PR DESCRIPTION
### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 🔧 Changes

This PR consists of 2 commits.

The first improves the locking of the KeyFunc by moving to a RWMutex, calling `RLock` in KeyFunc to allow multiple readers when retrieving the cached value and only calling the `Lock` method when we need to refresh the JWKS.

The second moves to refreshing the JWKS in the background when the CacheTTL is hit rather than blocking until the JWKS has been refreshed.  Previously, whenever the cached JWKS expired there would be a block until the request has completed
and the cache has been updated. Now, when the JWKS cache expires the refresh is triggered in the background and the cached JWKS will continue to be returned until the background refresh has been completed. If that background refresh succeeds then the cache will be updated, if it errors then the cached JWKS will be deleted and on the next call of KeyFunc the JWKS refresh will be attempted again, which (if the error persists) would raise the error.

This now means that the only time KeyFunc will block is in the instance where there is no JWKS for
an issuer, when a cached JWKS expires we will no longer block

### 📚 References

#194

### 🔬 Testing

Have tested this with the sample app/in repo example and is covered by tests
