### PR TITLE
Add option to skip issuer URL verification

### DIFF
--- a/validator/option.go
+++ b/validator/option.go
@@ -26,3 +26,13 @@ func WithCustomClaims(f func() CustomClaims) Option {
 		v.customClaims = f
 	}
 }
+
+// WithSkipIssuerURLVerification is an option which sets up the allowed
+// clock skew for the token. Note that in order to use this
+// the expected claims Time field MUST not be time.IsZero().
+// If this option is not used clock skew is not allowed.
+func WithSkipIssuerURLVerification(skip bool) Option {
+	return func(v *Validator) {
+		v.skipIssuerURLVerification = skip
+	}
+}


### PR DESCRIPTION
The validator checks if the issuer URL and aud inside the access token match their corresponding provided configuration. It is possible to pass multiple audiences to the validator, but it is not possible to provide multiple issuer URLs. Without breaking and changing a lot of code, it seems the easiest way to allow for multiple applications (-> issuer URLs) was to just skip the issuer URL validation.

Afaik this does still comply with the specifications.

### 📝 Checklist

- [ x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

Where am I suppose to add the documentation?

### 🔧 Changes

A validator option called `SkipIssuerURLVerification` was added to skip the verification of issuer URLs in access tokens.

### 📚 References

https://github.com/auth0/go-jwt-middleware/issues/197
https://github.com/auth0/go-jwt-middleware/pull/276

### 🔬 Testing

See test in validator_test.go
