### PR TITLE
fix(oidc): Validate HTTP response status and improve error messaging in OIDC (#308)

### DIFF
--- a/internal/oidc/oidc.go
+++ b/internal/oidc/oidc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -24,18 +25,24 @@ func GetWellKnownEndpointsFromIssuerURL(
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, issuerURL.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("could not build request to get well known endpoints: %w", err)
+		return nil, fmt.Errorf("could not build request to get well-known endpoints: %w", err)
 	}
 
 	response, err := httpClient.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("could not get well known endpoints from url %s: %w", issuerURL.String(), err)
+		return nil, fmt.Errorf("could not fetch well-known endpoints from %s: %w", issuerURL.String(), err)
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		body, _ := io.ReadAll(response.Body)
+		return nil, fmt.Errorf("received HTTP %d from %s: %s",
+			response.StatusCode, issuerURL.String(), string(body))
+	}
+
 	var wkEndpoints WellKnownEndpoints
-	if err = json.NewDecoder(response.Body).Decode(&wkEndpoints); err != nil {
-		return nil, fmt.Errorf("could not decode json body when getting well known endpoints: %w", err)
+	if err := json.NewDecoder(response.Body).Decode(&wkEndpoints); err != nil {
+		return nil, fmt.Errorf("failed to decode JSON response from %s: %w", issuerURL.String(), err)
 	}
 
 	return &wkEndpoints, nil

--- a/internal/oidc/oidc_test.go
+++ b/internal/oidc/oidc_test.go
@@ -1,0 +1,138 @@
+package oidc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// setupTestServer creates a test HTTP server that returns the specified response code and body.
+func setupTestServer(responseCode int, responseBody string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(responseCode)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+}
+
+// TestGetWellKnownEndpointsFromIssuerURL tests various scenarios for GetWellKnownEndpointsFromIssuerURL.
+func TestGetWellKnownEndpointsFromIssuerURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		responseCode int
+		responseBody string
+		expectError  bool
+	}{
+		{
+			name:         "Successful 200 response with valid JSON",
+			responseCode: http.StatusOK,
+			responseBody: `{"jwks_uri":"https://example.com/jwks"}`,
+			expectError:  false,
+		},
+		{
+			name:         "404 Not Found response",
+			responseCode: http.StatusNotFound,
+			responseBody: `{"error": "not found"}`,
+			expectError:  true,
+		},
+		{
+			name:         "500 Internal Server Error response",
+			responseCode: http.StatusInternalServerError,
+			responseBody: `Internal Server Error`,
+			expectError:  true,
+		},
+		{
+			name:         "Malformed JSON response",
+			responseCode: http.StatusOK,
+			responseBody: `{"jwks_uri": "https://example.com/jwks"`, // Missing closing brace
+			expectError:  true,
+		},
+		{
+			name:         "Empty response",
+			responseCode: http.StatusOK,
+			responseBody: ``,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := setupTestServer(tt.responseCode, tt.responseBody)
+			defer server.Close()
+
+			issuerURL, _ := url.Parse(server.URL)
+			ctx := context.Background()
+			client := &http.Client{}
+			_, err := GetWellKnownEndpointsFromIssuerURL(ctx, client, *issuerURL)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// Simulate a network failure scenario
+func TestGetWellKnownEndpoints_NetworkError(t *testing.T) {
+	client := &http.Client{}
+	invalidURL, _ := url.Parse("http://invalid.local")
+	_, err := GetWellKnownEndpointsFromIssuerURL(context.Background(), client, *invalidURL)
+
+	if err == nil || !strings.Contains(err.Error(), "could not fetch well-known endpoints") {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+// Simulate a timeout scenario
+func TestGetWellKnownEndpoints_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: 1 * time.Second}
+	issuerURL, _ := url.Parse(server.URL)
+	_, err := GetWellKnownEndpointsFromIssuerURL(context.Background(), client, *issuerURL)
+
+	if err == nil || !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Errorf("Expected timeout error, got: %v", err)
+	}
+}
+
+// Test invalid URL construction
+func TestGetWellKnownEndpoints_InvalidURL(t *testing.T) {
+	client := &http.Client{}
+	invalidURL := url.URL{} // Empty URL
+	_, err := GetWellKnownEndpointsFromIssuerURL(context.Background(), client, invalidURL)
+
+	if err == nil || !strings.Contains(err.Error(), "unsupported protocol scheme") {
+		t.Errorf("Expected URL construction error, got: %v", err)
+	}
+}
+
+// Test response body read failure
+func TestGetWellKnownEndpoints_BodyReadFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+	}))
+	server.CloseClientConnections()
+	defer server.Close()
+
+	client := &http.Client{}
+	issuerURL, _ := url.Parse(server.URL)
+	_, err := GetWellKnownEndpointsFromIssuerURL(context.Background(), client, *issuerURL)
+
+	if err == nil || !strings.Contains(err.Error(), "failed to decode JSON") {
+		t.Errorf("Expected body read failure error, got: %v", err)
+	}
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 🔧 Changes

This PR updates the `GetWellKnownEndpointsFromIssuerURL` function in `internal/oidc/oidc.go` to:  
- Validate the HTTP response status before attempting to deserialize the body.  
- Improve error handling by including the response body in error messages.  

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

- Fixes #308  

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

- Unit tests have been added to verify that the function correctly handles various HTTP response codes.  

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
