### PR TITLE
[SDK-5703] [GH-283] Add support for exclusion URLs in JWT middleware

### DIFF
--- a/option.go
+++ b/option.go
@@ -1,5 +1,9 @@
 package jwtmiddleware
 
+import (
+	"net/http"
+)
+
 // Option is how options for the JWTMiddleware are set up.
 type Option func(*JWTMiddleware)
 
@@ -42,5 +46,23 @@ func WithErrorHandler(h ErrorHandler) Option {
 func WithTokenExtractor(e TokenExtractor) Option {
 	return func(m *JWTMiddleware) {
 		m.tokenExtractor = e
+	}
+}
+
+// WithExclusionUrls allows configuring the exclusion URL handler with multiple URLs
+// that should be excluded from JWT validation.
+func WithExclusionUrls(exclusions []string) Option {
+	return func(m *JWTMiddleware) {
+		m.exclusionUrlHandler = func(r *http.Request) bool {
+			requestFullURL := r.URL.String()
+			requestPath := r.URL.Path
+
+			for _, exclusion := range exclusions {
+				if requestFullURL == exclusion || requestPath == exclusion {
+					return true
+				}
+			}
+			return false
+		}
 	}
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, please use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 🔧 Changes

- Added `exclusionUrlHandler` property to the `JWTMiddleware` struct.
- Introduced a new option `WithExclusionUrls`, which accepts a slice of strings.
- Updated the code to handle exclusion URLs appropriately.

### 📚 References

<!--
- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- GH-283

### 🔬 Testing


- Test cases have been added to cover the new functionality, specifically the `exclusionUrlHandler` property and the `WithExclusionUrls` option.
- Ensure that exclusion URLs are handled correctly by the middleware.
- Manual testing should verify the proper exclusion of URLs as per the updated logic.

