### PR TITLE
chore: Add SCA scan workflow

### DIFF
--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -1,0 +1,15 @@
+name: SCA
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  snyk-cli:
+    uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
+    with:
+      additional-arguments: "--exclude=README.md"
+      go-version: "1.24"
+    secrets: inherit


### PR DESCRIPTION
### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 🔧 Changes

Adds a new GitHub Actions workflow (`.github/workflows/sca_scan.yml`) for Software Composition Analysis (SCA) scanning using Snyk. The workflow:

- Calls the reusable `auth0/devsecops-tooling/.github/workflows/sca-scan.yml` workflow
- Triggers on pushes and pull requests to `master`
- Targets Go 1.24 to match the project's `go.mod`
- Excludes `README.md` from scanning

### 📚 References

- Source workflow: https://github.com/auth0/go-auth0/blob/main/.github/workflows/sca_scan.yml

### 🔬 Testing

This is a CI workflow addition. It will be validated when the workflow runs on this PR and on subsequent pushes and pull requests to master.