### PR TITLE
feat(validator): add WithRegisteredClaimsValidator option

### DIFF
--- a/validator/option.go
+++ b/validator/option.go
@@ -233,6 +233,41 @@ func WithAllowedClockSkew(skew time.Duration) Option {
 	}
 }
 
+// WithRegisteredClaimsValidator sets a validation function that runs against the
+// registered claims (iss, sub, aud, exp, nbf, iat, jti) after standard validation
+// (issuer and audience checks) has passed.
+//
+// Use this for enforcing constraints on registered claims beyond the built-in
+// issuer and audience checks. For example: requiring subject presence, validating
+// subject format, requiring expiry, or checking JTI against a revocation list.
+//
+// Only one registered claims validator can be set. If called multiple times,
+// the last one wins.
+//
+// Example:
+//
+//	validator.New(
+//	    // ... other options
+//	    validator.WithRegisteredClaimsValidator(func(claims validator.RegisteredClaims) error {
+//	        if claims.Subject == "" {
+//	            return errors.New("subject is required")
+//	        }
+//	        if claims.Expiry == 0 {
+//	            return errors.New("expiry is required")
+//	        }
+//	        return nil
+//	    }),
+//	)
+func WithRegisteredClaimsValidator(fn func(claims RegisteredClaims) error) Option {
+	return func(v *Validator) error {
+		if fn == nil {
+			return errors.New("registered claims validator function cannot be nil")
+		}
+		v.registeredClaimsValidator = fn
+		return nil
+	}
+}
+
 // WithCustomClaims sets a function that returns a CustomClaims object
 // for unmarshalling and validation.
 //

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -67,13 +67,14 @@ const (
 
 // Validator validates JWTs using the jwx v3 library.
 type Validator struct {
-	keyFunc           func(context.Context) (any, error)          // Required.
-	allowedAlgorithms []SignatureAlgorithm                        // Required.
-	expectedIssuers   []string                                    // Required (unless issuersResolver is set).
-	expectedAudiences []string                                    // Required.
-	customClaims      func() CustomClaims                         // Optional.
-	allowedClockSkew  time.Duration                               // Optional.
-	issuersResolver   func(ctx context.Context) ([]string, error) // Optional: dynamic issuer resolution.
+	keyFunc                    func(context.Context) (any, error)                    // Required.
+	allowedAlgorithms          []SignatureAlgorithm                                  // Required.
+	expectedIssuers            []string                                              // Required (unless issuersResolver is set).
+	expectedAudiences          []string                                              // Required.
+	customClaims               func() CustomClaims                                   // Optional.
+	allowedClockSkew           time.Duration                                         // Optional.
+	issuersResolver            func(ctx context.Context) ([]string, error)           // Optional: dynamic issuer resolution.
+	registeredClaimsValidator func(claims RegisteredClaims) error // Optional: custom registered claims validation.
 }
 
 // SignatureAlgorithm is a signature algorithm.
@@ -127,6 +128,7 @@ const DPoPSupportedAlgorithms = "ES256 ES384 ES512 RS256 RS384 RS512 PS256 PS384
 //   - WithAudience or WithAudiences: Expected audience claim(s) (aud)
 //
 // Optional options:
+//   - WithRegisteredClaimsValidator: Custom validation of registered claims (sub, exp, jti, etc.)
 //   - WithCustomClaims: Custom claims validation
 //   - WithAllowedClockSkew: Clock skew tolerance for time-based claims (default: 0)
 //
@@ -347,6 +349,13 @@ func (v *Validator) extractAndValidateClaims(ctx context.Context, token jwt.Toke
 		Expiry:    timeToUnix(expiration),
 		NotBefore: timeToUnix(notBefore),
 		IssuedAt:  timeToUnix(issuedAt),
+	}
+
+	// Run registered claims validator
+	if v.registeredClaimsValidator != nil {
+		if err := v.registeredClaimsValidator(registeredClaims); err != nil {
+			return nil, core.NewValidationError(core.ErrorCodeInvalidClaims, "registered claims validation failed", err)
+		}
 	}
 
 	// Handle custom claims if configured

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -67,14 +67,14 @@ const (
 
 // Validator validates JWTs using the jwx v3 library.
 type Validator struct {
-	keyFunc                    func(context.Context) (any, error)                    // Required.
-	allowedAlgorithms          []SignatureAlgorithm                                  // Required.
-	expectedIssuers            []string                                              // Required (unless issuersResolver is set).
-	expectedAudiences          []string                                              // Required.
-	customClaims               func() CustomClaims                                   // Optional.
-	allowedClockSkew           time.Duration                                         // Optional.
-	issuersResolver            func(ctx context.Context) ([]string, error)           // Optional: dynamic issuer resolution.
-	registeredClaimsValidator func(claims RegisteredClaims) error // Optional: custom registered claims validation.
+	keyFunc                   func(context.Context) (any, error)          // Required.
+	allowedAlgorithms         []SignatureAlgorithm                        // Required.
+	expectedIssuers           []string                                    // Required (unless issuersResolver is set).
+	expectedAudiences         []string                                    // Required.
+	customClaims              func() CustomClaims                         // Optional.
+	allowedClockSkew          time.Duration                               // Optional.
+	issuersResolver           func(ctx context.Context) ([]string, error) // Optional: dynamic issuer resolution.
+	registeredClaimsValidator func(claims RegisteredClaims) error         // Optional: custom registered claims validation.
 }
 
 // SignatureAlgorithm is a signature algorithm.

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -1402,3 +1402,162 @@ func generateTestTokenWithKid(t *testing.T, issuer, audience string, secret []by
 
 	return string(signed)
 }
+
+func TestWithRegisteredClaimsValidator(t *testing.T) {
+	const (
+		issuer   = "https://go-jwt-middleware.eu.auth0.com/"
+		audience = "https://go-jwt-middleware-api/"
+	)
+
+	keyFunc := func(context.Context) (any, error) {
+		return []byte("secret"), nil
+	}
+
+	t.Run("successfully creates validator with registered claims validator", func(t *testing.T) {
+		v, err := New(
+			WithKeyFunc(keyFunc),
+			WithAlgorithm(HS256),
+			WithIssuer(issuer),
+			WithAudience(audience),
+			WithRegisteredClaimsValidator(func(claims RegisteredClaims) error {
+				return nil
+			}),
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, v)
+		assert.NotNil(t, v.registeredClaimsValidator)
+	})
+
+	t.Run("returns error when validator function is nil", func(t *testing.T) {
+		_, err := New(
+			WithKeyFunc(keyFunc),
+			WithAlgorithm(HS256),
+			WithIssuer(issuer),
+			WithAudience(audience),
+			WithRegisteredClaimsValidator(nil),
+		)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "registered claims validator function cannot be nil")
+	})
+}
+
+func TestValidateToken_WithRegisteredClaimsValidator(t *testing.T) {
+	const (
+		issuer   = "https://go-jwt-middleware.eu.auth0.com/"
+		audience = "https://go-jwt-middleware-api/"
+	)
+
+	secret := []byte("secret")
+	keyFunc := func(context.Context) (any, error) {
+		return secret, nil
+	}
+
+	t.Run("passes when registered claims validator succeeds", func(t *testing.T) {
+		token := generateTestToken(t, issuer, audience, secret)
+
+		v, err := New(
+			WithKeyFunc(keyFunc),
+			WithAlgorithm(HS256),
+			WithIssuer(issuer),
+			WithAudience(audience),
+			WithRegisteredClaimsValidator(func(claims RegisteredClaims) error {
+				if claims.Subject == "" {
+					return errors.New("subject is required")
+				}
+				return nil
+			}),
+		)
+		require.NoError(t, err)
+
+		claims, err := v.ValidateToken(context.Background(), token)
+		assert.NoError(t, err)
+		assert.NotNil(t, claims)
+
+		validated := claims.(*ValidatedClaims)
+		assert.Equal(t, "1234567890", validated.RegisteredClaims.Subject)
+	})
+
+	t.Run("fails when registered claims validator rejects token", func(t *testing.T) {
+		token := generateTestToken(t, issuer, audience, secret)
+
+		v, err := New(
+			WithKeyFunc(keyFunc),
+			WithAlgorithm(HS256),
+			WithIssuer(issuer),
+			WithAudience(audience),
+			WithRegisteredClaimsValidator(func(claims RegisteredClaims) error {
+				if claims.ID == "" {
+					return errors.New("jti is required")
+				}
+				return nil
+			}),
+		)
+		require.NoError(t, err)
+
+		// generateTestToken does not include jti
+		claims, err := v.ValidateToken(context.Background(), token)
+		assert.Error(t, err)
+		assert.Nil(t, claims)
+		assert.Contains(t, err.Error(), "registered claims validation failed")
+		assert.Contains(t, err.Error(), "jti is required")
+
+		var validationErr *core.ValidationError
+		assert.True(t, errors.As(err, &validationErr))
+		assert.Equal(t, core.ErrorCodeInvalidClaims, validationErr.Code)
+	})
+
+	t.Run("validator receives correct claims values", func(t *testing.T) {
+		token := generateTestToken(t, issuer, audience, secret)
+
+		var receivedClaims RegisteredClaims
+		v, err := New(
+			WithKeyFunc(keyFunc),
+			WithAlgorithm(HS256),
+			WithIssuer(issuer),
+			WithAudience(audience),
+			WithRegisteredClaimsValidator(func(claims RegisteredClaims) error {
+				receivedClaims = claims
+				return nil
+			}),
+		)
+		require.NoError(t, err)
+
+		_, err = v.ValidateToken(context.Background(), token)
+		require.NoError(t, err)
+
+		assert.Equal(t, issuer, receivedClaims.Issuer)
+		assert.Equal(t, "1234567890", receivedClaims.Subject)
+		assert.Equal(t, []string{audience}, receivedClaims.Audience)
+		assert.NotZero(t, receivedClaims.Expiry)
+	})
+
+	t.Run("works alongside custom claims", func(t *testing.T) {
+		// Token with scope claim
+		token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2dvLWp3dC1taWRkbGV3YXJlLmV1LmF1dGgwLmNvbS8iLCJzdWIiOiIxMjM0NTY3ODkwIiwiYXVkIjpbImh0dHBzOi8vZ28tand0LW1pZGRsZXdhcmUtYXBpLyJdLCJzY29wZSI6InJlYWQ6bWVzc2FnZXMifQ.oqtUZQ-Q8un4CPduUBdGVq5gXpQVIFT_QSQjkOXFT5I"
+
+		v, err := New(
+			WithKeyFunc(keyFunc),
+			WithAlgorithm(HS256),
+			WithIssuer(issuer),
+			WithAudience(audience),
+			WithRegisteredClaimsValidator(func(claims RegisteredClaims) error {
+				if claims.Subject == "" {
+					return errors.New("subject is required")
+				}
+				return nil
+			}),
+			WithCustomClaims(func() *testClaims {
+				return &testClaims{}
+			}),
+		)
+		require.NoError(t, err)
+
+		claims, err := v.ValidateToken(context.Background(), token)
+		assert.NoError(t, err)
+		assert.NotNil(t, claims)
+
+		validated := claims.(*ValidatedClaims)
+		assert.Equal(t, "1234567890", validated.RegisteredClaims.Subject)
+		assert.Equal(t, "read:messages", validated.CustomClaims.(*testClaims).Scope)
+	})
+}


### PR DESCRIPTION
### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 🔧 Changes

Adds a new optional `WithRegisteredClaimsValidator` option to the validator package. This allows users to enforce constraints on registered claims (sub, exp, nbf, iat, jti) beyond the built-in issuer and audience checks, without needing to create a full CustomClaims struct.

**Usage:**

```go
validator.New(
    validator.WithRegisteredClaimsValidator(func(claims validator.RegisteredClaims) error {
        if claims.Subject == "" {
            return errors.New("subject is required")
        }
        return nil
    }),
)
```

- Runs after issuer and audience validation, before custom claims extraction
- Single function (last one wins if called multiple times)
- Returns `ErrorCodeInvalidClaims` on failure
- No context parameter — pure structural checks on already-parsed values

### 📚 References

- Closes #374

### 🔬 Testing

6 new tests covering:
- Successful construction with validator
- Nil function rejection
- Token passes when validator succeeds
- Token rejected when validator returns error (with correct error code)
- Validator receives correct claims values
- Works alongside WithCustomClaims

Full test suite passes with zero regressions.