### PR TITLE
fix(validator): select JWKS keys that omit the optional alg member

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -368,6 +368,17 @@ provider, err := jwks.NewCachingProvider(
 )
 ```
 
+#### Signing keys without an `alg` member
+
+In v2, go-jose derived the signing algorithm from the token's JWS protected
+header, so a JWKS whose keys omitted the optional `alg` member (which RFC 7517
+§4.4 allows) verified without any extra configuration. v3 uses jwx, which derives
+the algorithm from the key type when a key has no `alg`, and the middleware
+enables this automatically. You do not need to change anything: the algorithm you
+pass to `WithAlgorithm`/`WithAlgorithms` is still enforced against the token
+header before any key is selected, so an alg-less JWKS verifies exactly as it did
+under v2.
+
 ### 4. Update Middleware
 
 #### Basic Middleware

--- a/examples/http-jwks-example/main_test.go
+++ b/examples/http-jwks-example/main_test.go
@@ -31,28 +31,43 @@ func TestHandler(t *testing.T) {
 		},
 	}
 
-	jwk := generateJWK(t)
+	// The JWKS is exercised in both shapes allowed by RFC 7517 §4.4: keys that
+	// publish the optional "alg" member and keys that omit it. Tokens verify the
+	// same way in both cases; the token header always carries alg=RS256.
+	jwksCases := []struct {
+		name       string
+		publishAlg bool
+	}{
+		{name: "JWKS with alg", publishAlg: true},
+		{name: "JWKS without alg", publishAlg: false},
+	}
 
-	testServer := setupTestServer(t, jwk)
-	defer testServer.Close()
+	for _, jwksCase := range jwksCases {
+		t.Run(jwksCase.name, func(t *testing.T) {
+			jwk := generateJWK(t)
 
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			request, err := http.NewRequest(http.MethodGet, "", nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			testServer := setupTestServer(t, jwk, jwksCase.publishAlg)
+			defer testServer.Close()
 
-			token := buildJWTForTesting(t, jwk, testServer.URL, test.subject, []string{"my-audience"})
-			request.Header.Set("Authorization", "Bearer "+token)
+			for _, test := range testCases {
+				t.Run(test.name, func(t *testing.T) {
+					request, err := http.NewRequest(http.MethodGet, "", nil)
+					if err != nil {
+						t.Fatal(err)
+					}
 
-			responseRecorder := httptest.NewRecorder()
+					token := buildJWTForTesting(t, jwk, testServer.URL, test.subject, []string{"my-audience"})
+					request.Header.Set("Authorization", "Bearer "+token)
 
-			mainHandler := setupHandler(testServer.URL, []string{"my-audience"})
-			mainHandler.ServeHTTP(responseRecorder, request)
+					responseRecorder := httptest.NewRecorder()
 
-			if want, got := test.wantStatusCode, responseRecorder.Code; want != got {
-				t.Fatalf("wanted status code %d, but got status code %d", want, got)
+					mainHandler := setupHandler(testServer.URL, []string{"my-audience"})
+					mainHandler.ServeHTTP(responseRecorder, request)
+
+					if want, got := test.wantStatusCode, responseRecorder.Code; want != got {
+						t.Fatalf("wanted status code %d, but got status code %d", want, got)
+					}
+				})
 			}
 		})
 	}
@@ -74,7 +89,7 @@ func generateJWK(t *testing.T) *jose.JSONWebKey {
 	}
 }
 
-func setupTestServer(t *testing.T, jwk *jose.JSONWebKey) (server *httptest.Server) {
+func setupTestServer(t *testing.T, jwk *jose.JSONWebKey, publishAlg bool) (server *httptest.Server) {
 	t.Helper()
 
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -91,8 +106,16 @@ func setupTestServer(t *testing.T, jwk *jose.JSONWebKey) (server *httptest.Serve
 				t.Fatal(err)
 			}
 		case "/.well-known/jwks.json":
+			// "alg" is an optional JWK member (RFC 7517 §4.4). When publishAlg is
+			// false the key omits it, so both shapes a provider may serve are
+			// exercised. The signing key keeps its algorithm either way, so the
+			// token header still carries alg=RS256.
+			publicKey := jwk.Public()
+			if !publishAlg {
+				publicKey.Algorithm = ""
+			}
 			jwks := jose.JSONWebKeySet{
-				Keys: []jose.JSONWebKey{jwk.Public()},
+				Keys: []jose.JSONWebKey{publicKey},
 			}
 			jsonData, err := json.Marshal(jwks)
 			if err != nil {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -284,10 +284,21 @@ func (v *Validator) parseToken(_ context.Context, tokenString string, key any) (
 	// token has no kid header, that key is used. This is required for symmetric MCD
 	// (HS256 keys typically don't use kid) and is safe because algorithm enforcement
 	// already happened in ValidateToken before reaching this point.
+	// WithInferAlgorithmFromKey(true) lets keys that omit the optional "alg" member
+	// (RFC 7517 §4.4 makes it optional, and some providers/configurations do not emit it)
+	// still be selected: jwx derives the algorithm from the key type and then matches it
+	// against the token's alg header. This cannot widen the algorithm policy - the header was already checked
+	// against v.allowedAlgorithms in ValidateToken, and inference only considers algorithms
+	// compatible with the key type, so alg-confusion (e.g. an HS256 token against an RSA
+	// key) is still rejected. Without this, alg-less keys contribute no verification
+	// candidate and every token fails as an "unverifiable signature".
 	// For single keys (byte slices, etc.), use WithKey with the configured algorithm.
 	switch k := key.(type) {
 	case jwk.Set:
-		parseOpts = append(parseOpts, jwt.WithKeySet(k, jws.WithUseDefault(true)))
+		parseOpts = append(parseOpts, jwt.WithKeySet(k,
+			jws.WithUseDefault(true),
+			jws.WithInferAlgorithmFromKey(true),
+		))
 	default:
 		if len(v.allowedAlgorithms) != 1 {
 			return nil, fmt.Errorf(

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -2,6 +2,8 @@ package validator
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -1964,5 +1966,118 @@ func TestWithMaxActorChainDepth(t *testing.T) {
 		)
 		require.NoError(t, err)
 		assert.Equal(t, defaultMaxActorChainDepth, v.maxActorChainDepth)
+	})
+}
+
+// TestValidator_JWKSWithoutAlg is a regression test for the case where a JWKS
+// key omits the optional "alg" member (RFC 7517 §4.4 makes it optional). Before
+// jws.WithInferAlgorithmFromKey was wired into parseToken, alg-less keys
+// contributed no verification candidate and every RS256 token verified against
+// such a key set failed with an unverifiable-signature error.
+func TestValidator_JWKSWithoutAlg(t *testing.T) {
+	const (
+		issuer   = "https://go-jwt-middleware.eu.auth0.com/"
+		audience = "https://go-jwt-middleware-api/"
+		kid      = "test-rsa-kid"
+	)
+
+	rsaPrivate, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	// buildSet returns a jwk.Set holding the RSA public key with the given kid.
+	// When withAlg is false the key omits the "alg" member, mirroring Auth0.
+	buildSet := func(t *testing.T, withAlg bool) jwk.Set {
+		t.Helper()
+
+		pubKey, err := jwk.Import(rsaPrivate.Public())
+		require.NoError(t, err)
+		require.NoError(t, pubKey.Set(jwk.KeyIDKey, kid))
+		require.NoError(t, pubKey.Set(jwk.KeyUsageKey, "sig"))
+		if withAlg {
+			require.NoError(t, pubKey.Set(jwk.AlgorithmKey, jwa.RS256()))
+		}
+
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(pubKey))
+
+		return set
+	}
+
+	// signRS256 produces a valid RS256 token carrying the matching kid header.
+	signRS256 := func(t *testing.T) string {
+		t.Helper()
+
+		token, err := jwt.NewBuilder().
+			Issuer(issuer).
+			Audience([]string{audience}).
+			Subject("1234567890").
+			Expiration(time.Now().Add(1 * time.Hour)).
+			Build()
+		require.NoError(t, err)
+
+		signKey, err := jwk.Import(rsaPrivate)
+		require.NoError(t, err)
+		require.NoError(t, signKey.Set(jwk.KeyIDKey, kid))
+
+		headers := jws.NewHeaders()
+		require.NoError(t, headers.Set(jws.KeyIDKey, kid))
+
+		signed, err := jwt.Sign(token, jwt.WithKey(jwa.RS256(), signKey, jws.WithProtectedHeaders(headers)))
+		require.NoError(t, err)
+
+		return string(signed)
+	}
+
+	newValidator := func(t *testing.T, set jwk.Set) *Validator {
+		t.Helper()
+
+		v, err := New(
+			WithKeyFunc(func(context.Context) (any, error) { return set, nil }),
+			WithAlgorithm(RS256),
+			WithIssuer(issuer),
+			WithAudience(audience),
+		)
+		require.NoError(t, err)
+
+		return v
+	}
+
+	t.Run("validates RS256 token when JWKS key omits alg", func(t *testing.T) {
+		v := newValidator(t, buildSet(t, false))
+
+		claims, err := v.ValidateToken(context.Background(), signRS256(t))
+		require.NoError(t, err)
+		assert.NotNil(t, claims)
+	})
+
+	t.Run("still validates RS256 token when JWKS key includes alg", func(t *testing.T) {
+		v := newValidator(t, buildSet(t, true))
+
+		claims, err := v.ValidateToken(context.Background(), signRS256(t))
+		require.NoError(t, err)
+		assert.NotNil(t, claims)
+	})
+
+	t.Run("rejects HS256 token forged against the alg-less RSA key", func(t *testing.T) {
+		// Classic algorithm-confusion payload: an HS256 token keyed on the RSA
+		// public key bytes. The header-alg allowlist rejects it before key
+		// selection, so inference never gets the chance to misuse the RSA key.
+		token, err := jwt.NewBuilder().
+			Issuer(issuer).
+			Audience([]string{audience}).
+			Subject("1234567890").
+			Expiration(time.Now().Add(1 * time.Hour)).
+			Build()
+		require.NoError(t, err)
+
+		headers := jws.NewHeaders()
+		require.NoError(t, headers.Set(jws.KeyIDKey, kid))
+		forged, err := jwt.Sign(token, jwt.WithKey(jwa.HS256(), rsaPrivate.PublicKey.N.Bytes(), jws.WithProtectedHeaders(headers)))
+		require.NoError(t, err)
+
+		v := newValidator(t, buildSet(t, false))
+
+		_, err = v.ValidateToken(context.Background(), string(forged))
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 🔧 Changes

When a JWKS key omits the optional `alg` member (RFC 7517 §4.4 makes it optional), jwx's key selection discarded the key, so every token verified against such a key set failed with `signature could not be verified with any of the keys`. This was a regression from v2, where go-jose derived the algorithm from the JWS protected header.

`parseToken` now passes `jws.WithInferAlgorithmFromKey(true)` alongside `jws.WithUseDefault(true)` on the `jwk.Set` branch. When a key has no `alg`, jwx infers the algorithm from the key type and matches it against the token's `alg` header.

This does not relax the algorithm policy. The token header is already validated against the configured `WithAlgorithm`/`WithAlgorithms` set before key selection, and inference only considers algorithms compatible with the key type, so algorithm-confusion (for example an HS256 token against an RSA key) is still rejected. Key sets that already include `alg` are unaffected, since that branch is taken before inference is consulted.

### 📚 References

Fixes #424

### 🔬 Testing

- New `TestValidator_JWKSWithoutAlg` in `validator/validator_test.go` covers three cases: an RS256 token verifies against an alg-less key set, still verifies against an alg-present key set, and an HS256 token forged against the RSA key is rejected.
- `examples/http-jwks-example` now serves the JWKS in both shapes (with and without `alg`) and runs the existing handler cases against each.
- Full suite passes with `go test ./...`.
